### PR TITLE
Fix subheader navigation

### DIFF
--- a/components/SubHeader.js
+++ b/components/SubHeader.js
@@ -50,7 +50,7 @@ export default function SubHeader() {
     router.push({
       pathname: "/game",
       query: {
-        sort: "nameAsc"
+        sort: "releaseDateAsc"
       }
     })
   }
@@ -99,7 +99,7 @@ export default function SubHeader() {
           href={{
             pathname: "/game",
             query: {
-              sort: "nameAsc"
+              sort: "releaseDateDesc"
             }
           }}
         >


### PR DESCRIPTION
Clicking on 'novidade' will redirect the user to the /game with correct search params